### PR TITLE
feature(vars for config and data state)

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/ignore
 #GRAPHISTRY_INVESTIGATIONS=./data/investigations
 #GRAPHISTRY_VIZ=./data/viz
 #PIVOT_CONFIG_FILES=/opt/graphistry/config/pivot.json
-#VIZ_CONFIG_FILES==/opt/graphistry/config/viz.json
+#VIZ_CONFIG_FILES=/opt/graphistry/config/viz.json
 #GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/opt/graphistry/apps/core/pivot/data
 #GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/graphistry
 

--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/ignore
 #GRAPHISTRY_INVESTIGATIONS=./data/investigations
 #GRAPHISTRY_VIZ=./data/viz
 #PIVOT_CONFIG_FILES=/opt/graphistry/config/pivot.json
+#VIZ_CONFIG_FILES==/opt/graphistry/config/viz.json
 #GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/opt/graphistry/apps/core/pivot/data
 #GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/graphistry
 

--- a/.env
+++ b/.env
@@ -1,11 +1,27 @@
 GRAPHISTRY_LOG_LEVEL=DEBUG
 
+# By default, persist no data, and prepopulate datasets with demos.
+# To pass in configs and persist generated data across runs (and drop demos),
+# comment out first sequence of vars and uncomment remaining.
+# Result is persisting data in host's ./data/*, including reading config ./data/config/pivot.json
+GRAPHISTRY_CONFIG=/dev/null
+GRAPHISTRY_INVESTIGATIONS=/dev/null
+GRAPHISTRY_VIZ=/dev/null
+GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/tmp/ignore
+GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/ignore
+#GRAPHISTRY_CONFIG=./data/config
+#GRAPHISTRY_INVESTIGATIONS=./data/investigations
+#GRAPHISTRY_VIZ=./data/viz
+#PIVOT_CONFIG_FILES=/opt/graphistry/config/pivot.json
+#GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/opt/graphistry/apps/core/pivot/data
+#GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/graphistry
+
+
 S3_ENABLED=false
 
 # S3_ACCESS=<YOUR AWS ACCESS KEY ID>
 # S3_SECRET=<YOUR AWS ACCESS KEY SECRET>
 
-# PIVOT_INTERNAL_IP_ACCEPTLIST=[]
 
 # If you do not specify a password, one will be generated for you
 # You can get that password with `docker-compose logs pivot | grep PIVOT_PASSWORD`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ The contents of the `.env` file should guide you through your complete setup
 ```
 GRAPHISTRY_LOG_LEVEL=DEBUG
 
+# By default, persist no data, and prepopulate datasets with demos.
+# To pass in configs and persist generated data across runs (and drop demos),
+# comment out first sequence of vars and uncomment remaining.
+# Result is persisting data in host's ./data/*, including reading config ./data/config/pivot.json
+GRAPHISTRY_CONFIG=/dev/null
+GRAPHISTRY_INVESTIGATIONS=/dev/null
+GRAPHISTRY_VIZ=/dev/null
+GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/tmp/ignore
+GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/ignore
+#GRAPHISTRY_CONFIG=./data/config
+#GRAPHISTRY_INVESTIGATIONS=./data/investigations
+#GRAPHISTRY_VIZ=./data/viz
+#PIVOT_CONFIG_FILES=/opt/graphistry/config/pivot.json
+#GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/opt/graphistry/apps/core/pivot/data
+#GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/graphistry
+
 S3_ENABLED=false
 
 # S3_ACCESS=<YOUR AWS ACCESS KEY ID>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/ignore
 #GRAPHISTRY_INVESTIGATIONS=./data/investigations
 #GRAPHISTRY_VIZ=./data/viz
 #PIVOT_CONFIG_FILES=/opt/graphistry/config/pivot.json
+#VIZ_CONFIG_FILES=/opt/graphistry/config/viz.json
 #GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR=/opt/graphistry/apps/core/pivot/data
 #GRAPHISTRY_VIZ_CONTAINER_DIR=/tmp/graphistry
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - mongo
     env_file:
       - .env
+    volumes:
+      - ${GRAPHISTRY_VIZ}:${GRAPHISTRY_VIZ_CONTAINER_DIR}
 
   pivot:
     image: spengler.grph.xyz/bundle/graphistry-pivot:2001
@@ -41,6 +43,9 @@ services:
       - .env
     links:
       - central
+    volumes:
+       - ${GRAPHISTRY_CONFIG}:/opt/graphistry/config
+       - ${GRAPHISTRY_INVESTIGATIONS}:${GRAPHISTRY_INVESTIGATIONS_CONTAINER_DIR}
 
   mongo:
     image: spengler.grph.xyz/bundle/mongo:3.2.20


### PR DESCRIPTION
Add env vars to persist pivot+viz state outside container and pass in pivot config

* Default: no state persistence, no pivot config
* Toggle .env comments: enables state persistence and user-provided pivot config
* Recommends: ./data/{config, pivot, viz}, with ./config/pivot.json
* Notes in README; adding broader info to graphistry-cli/docs
* Note: written in a slightly weird way so that can be done without changing docker-compose.yml. Important so that during upgrades, can replace docker-compose.yml and only maintain .env .
* Note: weird side-effect of enabling persistence is that breaks demo datasets (as demo datasets folder is no longer the mounted viz one). so while i rather persistence on by default, not doing so interim b/c of this.

Also remove `PIVOT_INTERNAL_IP_ACCEPTLIST=[]` because that's clearer inside a data/config/pivot.json .

This will likely change once we switch to postgres.